### PR TITLE
Add ifdefs for Windows-only constants

### DIFF
--- a/src/lib/ccl_event_wrapper.c
+++ b/src/lib/ccl_event_wrapper.c
@@ -276,6 +276,7 @@ const char * ccl_event_get_final_name(CCLEvent * evt) {
             case CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR:
                 final_name = "GL_FENCE_SYNC_OBJECT_KHR";
                 break;
+            #if defined(__MSC_VER)
             case CL_COMMAND_ACQUIRE_D3D10_OBJECTS_KHR:
                 final_name = "ACQUIRE_D3D10_OBJECTS_KHR";
                 break;
@@ -294,6 +295,7 @@ const char * ccl_event_get_final_name(CCLEvent * evt) {
             case CL_COMMAND_RELEASE_D3D11_OBJECTS_KHR:
                 final_name = "RELEASE_D3D11_OBJECTS_KHR";
                 break;
+            #endif
             case CL_COMMAND_ACQUIRE_EGL_OBJECTS_KHR:
                 final_name = "ACQUIRE_EGL_OBJECTS_KHR";
                 break;

--- a/src/lib/ccl_oclversions.h
+++ b/src/lib/ccl_oclversions.h
@@ -32,7 +32,7 @@
     #include <OpenCL/opencl.h>
 #else
     #include <CL/opencl.h>
-    #ifdef CL_VERSION_1_2
+    #if defined(CL_VERSION_1_2) && defined(__MSC_VER)
         #include <CL/cl_dx9_media_sharing.h>
     #endif
 #endif


### PR DESCRIPTION
While building `cf4ocl` in Homebrew (https://github.com/Homebrew/homebrew-core/pull/106245), we found the build failed on Linux because some DirectX constants are undefined on Linux.  The fix for this is simply to use `#if defined(__MSC_VER)` so that DirectX-related code is only used on Windows.